### PR TITLE
fix: photo sent without file extension at the name

### DIFF
--- a/src/components/CameraComponent.jsx
+++ b/src/components/CameraComponent.jsx
@@ -56,16 +56,15 @@ const CameraComponent = () => {
 
   const headers = {
     'Authorization': 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6MywiaWF0IjoxNzE0NDQwNjU5LCJleHAiOjE3NDU5OTgyNTl9.xMTwGmMHZkP1PLr61pzuGIzh2Xuok-_LZ3U8FKb5Rwc',
-    
   };
   
 
   
   // Construção dos dados do formulário
 const formData = new FormData();
-formData.append('photo', imageConverted); // 'imageConverted' é a sua variável que contém o Blob da imagem
-formData.append('longitude', latitude);
-formData.append('latitude', longitude);
+formData.append('photo', imageConverted, `${Date.now()}.jpeg`); // 'imageConverted' é a sua variável que contém o Blob da imagem
+formData.append('longitude', longitude);
+formData.append('latitude', latitude);
 console.log(formData)
   
   axios.post('http://localhost:3000/photos', formData, { headers })


### PR DESCRIPTION
The photo was getting at the api but not openable (without extension, because the extension is added to the filename if the originalname has an extesion with it). Know the photo gets as .jpeg and its originalname gets an unique name (not 'Blob').